### PR TITLE
Fix issue416: Unexpected LF when formatting a list o references

### DIFF
--- a/src/main/java/org/yaml/snakeyaml/DumperOptions.java
+++ b/src/main/java/org/yaml/snakeyaml/DumperOptions.java
@@ -187,6 +187,7 @@ public class DumperOptions {
     private boolean allowReadOnlyProperties = false;
     private int indent = 2;
     private int indicatorIndent = 0;
+    private boolean indentWithIndicator = false;
     private int bestWidth = 80;
     private boolean splitLines = true;
     private LineBreak lineBreak = LineBreak.UNIX;
@@ -263,6 +264,14 @@ public class DumperOptions {
 
     public int getIndicatorIndent() {
         return this.indicatorIndent;
+    }
+
+    public boolean getIndentWithIndicator() {
+        return indentWithIndicator;
+    }
+
+    public void setIndentWithIndicator(boolean indentWithIndicator) {
+        this.indentWithIndicator = indentWithIndicator;
     }
 
     public void setVersion(Version version) {

--- a/src/main/java/org/yaml/snakeyaml/Yaml.java
+++ b/src/main/java/org/yaml/snakeyaml/Yaml.java
@@ -193,7 +193,7 @@ public class Yaml {
         this.constructor = constructor;
         this.constructor.setAllowDuplicateKeys(loadingConfig.isAllowDuplicateKeys());
         this.constructor.setWrappedToRootException(loadingConfig.isWrappedToRootException());
-        if (dumperOptions.getIndent() <= dumperOptions.getIndicatorIndent()) {
+        if (!dumperOptions.getIndentWithIndicator() && dumperOptions.getIndent() <= dumperOptions.getIndicatorIndent()) {
             throw new YAMLException("Indicator indent must be smaller then indent.");
         }
         representer.setDefaultFlowStyle(dumperOptions.getDefaultFlowStyle());

--- a/src/main/java/org/yaml/snakeyaml/emitter/Emitter.java
+++ b/src/main/java/org/yaml/snakeyaml/emitter/Emitter.java
@@ -149,6 +149,7 @@ public final class Emitter implements Emitable {
     private final boolean allowUnicode;
     private int bestIndent;
     private final int indicatorIndent;
+    private final boolean indentWithIndicator;
     private int bestWidth;
     private final char[] bestLineBreak;
     private final boolean splitLines;
@@ -206,6 +207,7 @@ public final class Emitter implements Emitable {
             this.bestIndent = opts.getIndent();
         }
         this.indicatorIndent = opts.getIndicatorIndent();
+        this.indentWithIndicator = opts.getIndentWithIndicator();
         this.bestWidth = 80;
         if (opts.getWidth() > this.bestIndent * 2) {
             this.bestWidth = opts.getWidth();
@@ -607,8 +609,13 @@ public final class Emitter implements Emitable {
                 state = states.pop();
             } else {
                 writeIndent();
-                writeWhitespace(indicatorIndent);
+                if (!indentWithIndicator || this.first) {
+                    writeWhitespace(indicatorIndent);
+                }
                 writeIndicator("-", true, false, true);
+                if (indentWithIndicator && this.first) {
+                    indent += indicatorIndent;
+                }
                 states.push(new ExpectBlockSequenceItem(false));
                 expectNode(false, false, false);
             }

--- a/src/test/java/org/yaml/snakeyaml/issues/issue416/IndentWithIndicatorTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue416/IndentWithIndicatorTest.java
@@ -1,0 +1,67 @@
+package org.yaml.snakeyaml.issues.issue416;
+
+import junit.framework.TestCase;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Util;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IndentWithIndicatorTest extends TestCase {
+    public void testIndentWithIndicator1() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setIndentWithIndicator(true);
+        options.setIndent(2);
+        options.setIndicatorIndent(1);
+
+        Yaml yaml = new Yaml(options);
+        String output = yaml.dump(createData());
+
+        String doc = Util.getLocalResource("issues/issue416_1.yml");
+
+        assertEquals(doc, output);
+    }
+
+    public void testIndentWithIndicator2() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setIndentWithIndicator(true);
+        options.setIndent(2);
+        options.setIndicatorIndent(2);
+
+        Yaml yaml = new Yaml(options);
+        String output = yaml.dump(createData());
+
+        String doc = Util.getLocalResource("issues/issue416_2.yml");
+
+        assertEquals(doc, output);
+    }
+
+    private Map<String, Object> createData() {
+        Map<String, String> fred = new LinkedHashMap<>();
+        fred.put("name", "Fred");
+        fred.put("role", "creator");
+
+        Map<String, String> john = new LinkedHashMap<>();
+        john.put("name", "John");
+        john.put("role", "committer");
+
+        List<Map<String, String>> developers = new ArrayList<>();
+        developers.add(fred);
+        developers.add(john);
+
+        Map<String, Object> company = new LinkedHashMap<>();
+        company.put("developers", developers);
+        company.put("name", "Yet Another Company");
+        company.put("location", "Maastricht");
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("company", company);
+
+        return data;
+    }
+}

--- a/src/test/resources/issues/issue416_1.yml
+++ b/src/test/resources/issues/issue416_1.yml
@@ -1,0 +1,8 @@
+company:
+  developers:
+   - name: Fred
+     role: creator
+   - name: John
+     role: committer
+  name: Yet Another Company
+  location: Maastricht

--- a/src/test/resources/issues/issue416_2.yml
+++ b/src/test/resources/issues/issue416_2.yml
@@ -1,0 +1,8 @@
+company:
+  developers:
+    - name: Fred
+      role: creator
+    - name: John
+      role: committer
+  name: Yet Another Company
+  location: Maastricht


### PR DESCRIPTION
## Changes:
- Added a new option of `IndentWithIndicator` 
this new option is  backwards compatible, when it is set to `true`, the `indicator indent` could be bigger than `indent`.
- How to use?
```
DumperOptions options = new DumperOptions();
options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
options.setIndentWithIndicator(true);  // set it to true
options.setIndent(2);
options.setIndicatorIndent(2);
```
than we could get the follow format:
```yaml
company:
  developers:
    - role: creator
      name: fred
    - role: committer
      name: John
```