### PR TITLE
Generic type deserialization support

### DIFF
--- a/src/main/java/org/yaml/snakeyaml/TypeReference.java
+++ b/src/main/java/org/yaml/snakeyaml/TypeReference.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+public class TypeReference<T> {
+    protected final Type type;
+
+    protected TypeReference() {
+        Type superClass = this.getClass().getGenericSuperclass();
+        if (superClass instanceof Class) {
+            throw new IllegalArgumentException("Internal error: TypeReference constructed without " +
+                    "actual type information");
+        } else {
+            this.type = ((ParameterizedType)superClass).getActualTypeArguments()[0];
+        }
+    }
+
+    public Type getType() {
+        return this.type;
+    }
+}

--- a/src/main/java/org/yaml/snakeyaml/Yaml.java
+++ b/src/main/java/org/yaml/snakeyaml/Yaml.java
@@ -40,6 +40,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -433,9 +434,12 @@ public class Yaml {
      * @param type Class of the object to be created
      * @return parsed object
      */
-    @SuppressWarnings("unchecked")
     public <T> T loadAs(Reader io, Class<T> type) {
-        return (T) loadFromReader(new StreamReader(io), type);
+        return loadFromReader(new StreamReader(io), type);
+    }
+
+    public <T> T loadAs(Reader io, TypeReference type) {
+        return loadFromReader(new StreamReader(io), type.type);
     }
 
     /**
@@ -447,11 +451,13 @@ public class Yaml {
      * @param type Class of the object to be created
      * @return parsed object
      */
-    @SuppressWarnings("unchecked")
     public <T> T loadAs(String yaml, Class<T> type) {
-        return (T) loadFromReader(new StreamReader(yaml), type);
+        return loadFromReader(new StreamReader(yaml), type);
     }
 
+    public <T> T loadAs(String yaml, TypeReference type) {
+        return loadFromReader(new StreamReader(yaml), type.type);
+    }
     /**
      * Parse the only YAML document in a stream and produce the corresponding
      * Java object.
@@ -461,12 +467,15 @@ public class Yaml {
      * @param type  Class of the object to be created
      * @return parsed object
      */
-    @SuppressWarnings("unchecked")
     public <T> T loadAs(InputStream input, Class<T> type) {
-        return (T) loadFromReader(new StreamReader(new UnicodeReader(input)), type);
+        return loadFromReader(new StreamReader(new UnicodeReader(input)), type);
     }
 
-    private Object loadFromReader(StreamReader sreader, Class<?> type) {
+    public <T> T loadAs(InputStream input, TypeReference type) {
+        return loadFromReader(new StreamReader(new UnicodeReader(input)), type.type);
+    }
+
+    private <T> T loadFromReader(StreamReader sreader, Type type) {
         Composer composer = new Composer(new ParserImpl(sreader), resolver, loadingConfig);
         constructor.setComposer(composer);
         return constructor.getSingleData(type);

--- a/src/main/java/org/yaml/snakeyaml/constructor/Construct.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/Construct.java
@@ -34,7 +34,7 @@ public interface Construct {
      *            composed Node
      * @return a complete Java instance
      */
-    Object construct(Node node);
+    <T> T construct(Node node);
 
     /**
      * Apply the second step when constructing recursive structures. Because the

--- a/src/main/java/org/yaml/snakeyaml/constructor/Constructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/Constructor.java
@@ -15,6 +15,7 @@
  */
 package org.yaml.snakeyaml.constructor;
 
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -242,6 +243,8 @@ public class Constructor extends SafeConstructor {
                     if (!typeDetected && valueNode.getNodeId() != NodeId.scalar) {
                         // only if there is no explicit TypeDescription
                         Class<?>[] arguments = property.getActualTypeArguments();
+                        Type genType = property.getGenType();
+                        node.setGenType(genType);
                         if (arguments != null && arguments.length > 0) {
                             // type safe (generic) collection may contain the
                             // proper class
@@ -249,17 +252,20 @@ public class Constructor extends SafeConstructor {
                                 Class<?> t = arguments[0];
                                 SequenceNode snode = (SequenceNode) valueNode;
                                 snode.setListType(t);
+                                snode.setGenType(genType);
                             } else if (Set.class.isAssignableFrom(valueNode.getType())) {
                                 Class<?> t = arguments[0];
                                 MappingNode mnode = (MappingNode) valueNode;
                                 mnode.setOnlyKeyType(t);
                                 mnode.setUseClassConstructor(true);
+                                mnode.setGenType(genType);
                             } else if (Map.class.isAssignableFrom(valueNode.getType())) {
                                 Class<?> ketType = arguments[0];
                                 Class<?> valueType = arguments[1];
                                 MappingNode mnode = (MappingNode) valueNode;
                                 mnode.setTypes(ketType, valueType);
                                 mnode.setUseClassConstructor(true);
+                                mnode.setGenType(genType);
                             }
                         }
                     }

--- a/src/main/java/org/yaml/snakeyaml/introspector/GenericProperty.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/GenericProperty.java
@@ -33,6 +33,11 @@ abstract public class GenericProperty extends Property {
     private boolean actualClassesChecked;
     private Class<?>[] actualClasses;
 
+    @Override
+    public Type getGenType() {
+        return genType;
+    }
+
     public Class<?>[] getActualTypeArguments() { // should we synchronize here ?
         if (!actualClassesChecked) {
             if (genType instanceof ParameterizedType) {

--- a/src/main/java/org/yaml/snakeyaml/introspector/Property.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/Property.java
@@ -16,6 +16,7 @@
 package org.yaml.snakeyaml.introspector;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.List;
 
 /**
@@ -46,6 +47,10 @@ public abstract class Property implements Comparable<Property> {
     }
 
     abstract public Class<?>[] getActualTypeArguments();
+
+    public Type getGenType() {
+        return null;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/org/yaml/snakeyaml/nodes/Node.java
+++ b/src/main/java/org/yaml/snakeyaml/nodes/Node.java
@@ -17,6 +17,8 @@ package org.yaml.snakeyaml.nodes;
 
 import org.yaml.snakeyaml.error.Mark;
 
+import java.lang.reflect.Type;
+
 /**
  * Base class for all nodes.
  * <p>
@@ -35,6 +37,7 @@ public abstract class Node {
     private Mark startMark;
     protected Mark endMark;
     private Class<? extends Object> type;
+    private Type genType;
     private boolean twoStepsConstruction;
     private String anchor;
 
@@ -49,6 +52,7 @@ public abstract class Node {
         this.startMark = startMark;
         this.endMark = endMark;
         this.type = Object.class;
+        this.genType = null;
         this.twoStepsConstruction = false;
         this.resolved = true;
         this.useClassConstructor = null;
@@ -104,6 +108,14 @@ public abstract class Node {
         if (!type.isAssignableFrom(this.type)) {
             this.type = type;
         }
+    }
+
+    public Type getGenType() {
+        return genType;
+    }
+
+    public void setGenType(Type genType) {
+        this.genType = genType;
     }
 
     public void setTwoStepsConstruction(boolean twoStepsConstruction) {

--- a/src/test/java/org/yaml/snakeyaml/issues/issue361/Document.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue361/Document.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue361;
+
+import java.util.List;
+import java.util.Map;
+
+public class Document {
+    List<Map<String, Property>> properties;
+
+    public List<Map<String, Property>> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<Map<String, Property>> properties) {
+        this.properties = properties;
+    }
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue361/GenericTypeTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue361/GenericTypeTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue361;
+
+import junit.framework.TestCase;
+import org.yaml.snakeyaml.TypeReference;
+import org.yaml.snakeyaml.Util;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.*;
+
+public class GenericTypeTest extends TestCase {
+
+    public void test_generic_type_bean_property() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue361-1.yml");
+        Document doc1 = yaml.loadAs(str, Document.class);
+        List<Map<String, Property>> properties = doc1.getProperties();
+        assert(properties.get(0).get("property1") instanceof Property);
+
+        Document doc2 = yaml.loadAs(str, new TypeReference<Document>() {});
+        properties = doc2.getProperties();
+        assert(properties.get(0).get("property1") instanceof Property);
+    }
+
+    public void test_ref_map() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue361-2.yml");
+        Map map = yaml.loadAs(str, new TypeReference<Map<String, Property>>(){});
+        assert(map.get("property") instanceof Property);
+
+        Map map2 = yaml.loadAs(str, new TypeReference<Map>(){});
+        assert(map2.get("property") instanceof LinkedHashMap);
+
+        Map map3 = yaml.loadAs(str, Map.class);
+        assert(map3.get("property") instanceof LinkedHashMap);
+    }
+
+    public void test_ref_list() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue361-3.yml");
+        List list1 = yaml.loadAs(str, new TypeReference<List<Property>>(){});
+        assert(list1.get(0) instanceof Property);
+
+        List list2 = yaml.loadAs(str, new TypeReference<List>(){});
+        assert(list2.get(0) instanceof LinkedHashMap);
+
+        List list3 = yaml.loadAs(str, List.class);
+        assert(list3.get(0) instanceof LinkedHashMap);
+    }
+
+    public void test_ref_list_of_map() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue361-4.yml");
+        List<Map<String, Property>> list = yaml.loadAs(str, new TypeReference<List<Map<String, Property>>>(){});
+        assert(list.get(0).get("property1") instanceof Property);
+
+        List list2 = yaml.loadAs(str, List.class);
+        assert(((Map)list2.get(0)).get("property1") instanceof LinkedHashMap);
+    }
+
+    public void test_ref_list_of_list() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue361-5.yml");
+        List<List> list = yaml.loadAs(str, new TypeReference<List<List<Property>>>(){});
+        assert(list.get(0).get(0) instanceof Property);
+
+        List<List> list2 = yaml.loadAs(str, List.class);
+        assert(list2.get(0).get(0) instanceof LinkedHashMap);
+    }
+
+    public void test_ref_map_of_list() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue361-6.yml");
+        Map<String, List<Property>> map = yaml.loadAs(str, new TypeReference<Map<String, List<Property>>>(){});
+        assert(map.get("property").get(0) instanceof Property);
+    }
+
+    public void test_ref_map_of_map() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue361-7.yml");
+        Map<String, Map<String, Property>> map = yaml.loadAs(str, new TypeReference<Map<String, Map<String, Property>>>(){});
+        assert(map.get("property").get("inner") instanceof Property);
+    }
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue361/GenericTypeTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue361/GenericTypeTest.java
@@ -95,4 +95,13 @@ public class GenericTypeTest extends TestCase {
         Map<String, Map<String, Property>> map = yaml.loadAs(str, new TypeReference<Map<String, Map<String, Property>>>(){});
         assert(map.get("property").get("inner") instanceof Property);
     }
+
+    public void test_list_of_bean() {
+        Yaml yaml = new Yaml();
+        String str = Util.getLocalResource("issues/issue387.yml");
+        List<TestCaseBean> tests = yaml.loadAs(str, new TypeReference<List<TestCaseBean>>(){});
+        assertEquals(2, tests.size());
+        assert(tests.get(0) instanceof TestCaseBean);
+        assert(tests.get(1) instanceof TestCaseBean);
+    }
 }

--- a/src/test/java/org/yaml/snakeyaml/issues/issue361/Property.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue361/Property.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue361;
+
+public class Property {
+    private String name;
+    private String type;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue361/TestCaseBean.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue361/TestCaseBean.java
@@ -1,0 +1,8 @@
+package org.yaml.snakeyaml.issues.issue361;
+
+import java.util.List;
+
+public class TestCaseBean {
+    public List<String> input;
+    public List<String> expected;
+}

--- a/src/test/resources/issues/issue361-1.yml
+++ b/src/test/resources/issues/issue361-1.yml
@@ -1,0 +1,7 @@
+properties:
+  - property1:
+      name: p1
+      type: t1
+  - property2:
+      name: p2
+      type: t2

--- a/src/test/resources/issues/issue361-2.yml
+++ b/src/test/resources/issues/issue361-2.yml
@@ -1,0 +1,4 @@
+property:
+  name: p1
+  type: t1
+

--- a/src/test/resources/issues/issue361-3.yml
+++ b/src/test/resources/issues/issue361-3.yml
@@ -1,0 +1,4 @@
+- name: p1
+  type: t1
+- name: p2
+  type: t2

--- a/src/test/resources/issues/issue361-4.yml
+++ b/src/test/resources/issues/issue361-4.yml
@@ -1,0 +1,6 @@
+- property1:
+    name: p1
+    type: t1
+- property2:
+    name: p2
+    type: t2

--- a/src/test/resources/issues/issue361-5.yml
+++ b/src/test/resources/issues/issue361-5.yml
@@ -1,0 +1,8 @@
+- - name: p1
+    type: t1
+  - name: p2
+    type: t2
+- - name: p1
+    type: t1
+  - name: p2
+    type: t2

--- a/src/test/resources/issues/issue361-6.yml
+++ b/src/test/resources/issues/issue361-6.yml
@@ -1,0 +1,5 @@
+property:
+  - name: p1
+    type: t1
+  - name: p2
+    type: t2

--- a/src/test/resources/issues/issue361-7.yml
+++ b/src/test/resources/issues/issue361-7.yml
@@ -1,0 +1,4 @@
+property:
+  inner:
+    name: p1
+    type: t1

--- a/src/test/resources/issues/issue387.yml
+++ b/src/test/resources/issues/issue387.yml
@@ -1,0 +1,12 @@
+- input:
+    - val1
+    - val2
+  expected:
+    - val3
+    - val4
+- input:
+    - val5
+    - val6
+  expected:
+    - val7
+    - val8


### PR DESCRIPTION
Fix for issue [#361: List<Map<String, Property>> does not create Property objects](https://bitbucket.org/asomov/snakeyaml/issues/361/list-does-not-create-property-objects) and [#387: Support for generic types when serializing and deserializing?](https://bitbucket.org/asomov/snakeyaml/issues/387/support-for-generic-types-when-serializing)
Changes:
- add `TypeReference` class
- add new API of `public <T> T loadAs(String/Reader/InputStream input, TypeReference type)`
- The return value type of some interfaces is changed from `Object` to `T`

changes above are compatible with old versions.

demo:
```java
List list1 = yaml.loadAs(str, new TypeReference<List<Property>>(){});
assert(list1.get(0) instanceof Property);

Map map = yaml.loadAs(str, new TypeReference<Map<String, Property>>(){});
assert(map.get("property") instanceof Property);

List<Map<String, Property>> list = yaml.loadAs(str, new TypeReference<List<Map<String, Property>>>(){});
assert(list.get(0).get("property1") instanceof Property);
```