### PR TITLE
Fix issue307: Add Annotation retrieval methods to `Property`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
     </developers>
     <dependencies>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/org/yaml/snakeyaml/YAMLField.java
+++ b/src/main/java/org/yaml/snakeyaml/YAMLField.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface YAMLField {
+    int order() default 0;
+}

--- a/src/main/java/org/yaml/snakeyaml/introspector/Property.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/Property.java
@@ -15,7 +15,12 @@
  */
 package org.yaml.snakeyaml.introspector;
 
+import org.yaml.snakeyaml.YAMLField;
+
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 
 /**
@@ -88,6 +93,45 @@ public abstract class Property implements Comparable<Property> {
      * @return property's annotation for the given type or {@code null} if it's not present
      */
     abstract public <A extends Annotation> A getAnnotation(Class<A> annotationType);
+
+    public Field getField(final Class<? extends Object> type,String fieldName) {
+        Field[] fields = type.getDeclaredFields();
+        int var1 = fields.length;
+        Field field;
+        for (int i = 0; i < var1; ++i) {
+            field = fields[i];
+            if (field.getName().equals(fieldName)) {
+                return field;
+            }
+        }
+        fields = type.getFields();
+        var1 = fields.length;
+        for (int i = 0; i < var1; ++i) {
+            field = fields[i];
+            if (field.getName().equals(fieldName)) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    public Object getYAMLFieldAnnotation(Field field, String annotationName){
+        try {
+            YAMLField yamlField = null;
+            if (field != null) {
+                yamlField = field.getAnnotation(YAMLField.class);
+            }
+            if (yamlField != null) {
+                Method method = yamlField.annotationType().getDeclaredMethod(annotationName);
+                if (method != null) {
+                    return method.invoke(yamlField, null);
+                }
+            }
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 
     @Override
     public int hashCode() {

--- a/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
+++ b/src/main/java/org/yaml/snakeyaml/introspector/PropertyUtils.java
@@ -22,12 +22,7 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.util.PlatformFeatureDetector;
@@ -133,8 +128,29 @@ public class PropertyUtils {
         return properties;
     }
 
-    protected Set<Property> createPropertySet(Class<? extends Object> type, BeanAccess bAccess) {
-        Set<Property> properties = new TreeSet<Property>();
+    protected Set<Property> createPropertySet(final Class<? extends Object> type, BeanAccess bAccess) {
+        Set<Property> properties = new TreeSet<Property>(new Comparator<Property>() {
+            @Override
+            public int compare(Property prop1, Property prop2) {
+                Field field1 = prop1.getField(type, prop1.getName());
+                Field field2 = prop2.getField(type, prop2.getName());
+                Integer integer1 = (Integer) prop1.getYAMLFieldAnnotation(field1, "order");
+                Integer integer2 = (Integer) prop2.getYAMLFieldAnnotation(field2, "order");
+                if (integer1 == null) {
+                    integer1 = 0;
+                }
+                if (integer2 == null) {
+                    integer2 = 0;
+                }
+                if (integer1 < integer2) {
+                    return -1;
+                }
+                if (integer1 > integer2) {
+                    return 1;
+                }
+                return prop1.getName().compareTo(prop2.getName());
+            }
+        });
         Collection<Property> props = getPropertiesMap(type, bAccess).values();
         for (Property property : props) {
             if (property.isReadable() && (allowReadOnlyProperties || property.isWritable())) {

--- a/src/test/java/org/yaml/snakeyaml/issues/issue307/AnnotationTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue307/AnnotationTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue307;
+
+import junit.framework.TestCase;
+import org.yaml.snakeyaml.Util;
+import org.yaml.snakeyaml.Yaml;
+
+public class AnnotationTest extends TestCase {
+
+    private String s = Util.getLocalResource("issues/issue307.yaml");;
+    private Yaml yaml = new Yaml();
+
+    public void test_sorted_in_order() {
+        YAMLFieldBean1 bean1 = yaml.loadAs(s, YAMLFieldBean1.class);
+        String dump = yaml.dump(bean1);
+        String s2 = "!!org.yaml.snakeyaml.issues.issue307.YAMLFieldBean1\n" +
+                "name: tian\n" +
+                "type: {z: 256, y: 255, x: 254}\n" +
+                "age: 22\n" +
+                "line: twelve\n" +
+                "text: omit\n";
+        assertEquals(dump,s2);
+    }
+
+    public void test_negative_order_prior_to_positive_order() {
+
+        YAMLFieldBean2 bean2 = yaml.loadAs(s, YAMLFieldBean2.class);
+        String dump = yaml.dump(bean2);
+        String s2 = "!!org.yaml.snakeyaml.issues.issue307.YAMLFieldBean2\n" +
+                "text: omit\n" +
+                "type: {z: 256, y: 255, x: 254}\n" +
+                "name: tian\n" +
+                "age: 22\n" +
+                "line: twelve\n";
+        assertEquals(dump,s2);
+    }
+
+    public void test_same_order_is_sorted_alpha() {
+        YAMLFieldBean3 bean3 = yaml.loadAs(s, YAMLFieldBean3.class);
+        String dump = yaml.dump(bean3);
+        String s2 = "!!org.yaml.snakeyaml.issues.issue307.YAMLFieldBean3\n" +
+                "line: twelve\n" +
+                "text: omit\n" +
+                "age: 22\n" +
+                "name: tian\n" +
+                "type: {z: 256, y: 255, x: 254}\n";
+        assertEquals(dump,s2);
+    }
+
+    public void test_default_order_is_0() {
+        YAMLFieldBean4 bean4 = yaml.loadAs(s, YAMLFieldBean4.class);
+        String dump = yaml.dump(bean4);
+        String s2 = "!!org.yaml.snakeyaml.issues.issue307.YAMLFieldBean4\n" +
+                "name: tian\n" +
+                "age: 22\n" +
+                "line: twelve\n" +
+                "type: {z: 256, y: 255, x: 254}\n" +
+                "text: omit\n";
+        assertEquals(dump,s2);
+    }
+
+    public void test_extend_order() {
+        YAMLFieldBean5 bean5 = yaml.loadAs(s, YAMLFieldBean5.class);
+        bean5.setPojoName("pojo");
+        String dump = yaml.dump(bean5);
+        String s2 = "!!org.yaml.snakeyaml.issues.issue307.YAMLFieldBean5\n" +
+                "pojoName: pojo\n" +
+                "name: tian\n" +
+                "type: {z: 256, y: 255, x: 254}\n" +
+                "age: 22\n" +
+                "line: twelve\n" +
+                "text: omit\n";
+        assertEquals(dump,s2);
+    }
+
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue307/Coordinates.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue307/Coordinates.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue307;
+
+import org.yaml.snakeyaml.YAMLField;
+
+public class Coordinates {
+
+    @YAMLField(order = 3)
+    public int x;
+
+    @YAMLField(order = 2)
+    public int y;
+
+    @YAMLField(order = 1)
+    public int z;
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean1.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean1.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue307;
+
+import lombok.Data;
+import org.yaml.snakeyaml.YAMLField;
+
+@Data
+public class YAMLFieldBean1 {
+
+    @YAMLField(order = 1)
+    public String name;
+
+    @YAMLField(order = 2)
+    public Coordinates type;
+
+    @YAMLField(order = 3)
+    public Integer age;
+
+    @YAMLField(order = 4)
+    public String line;
+
+    @YAMLField(order = 5)
+    public String text;
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean2.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean2.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue307;
+
+import lombok.Data;
+import org.yaml.snakeyaml.YAMLField;
+
+@Data
+public class YAMLFieldBean2 {
+
+    @YAMLField(order = 1)
+    private String name;
+
+    @YAMLField(order = -2)
+    private Coordinates type;
+
+    @YAMLField(order = 3)
+    private Integer age;
+
+    @YAMLField(order = 4)
+    private String line;
+
+    @YAMLField(order = -5)
+    private String text;
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean3.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean3.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue307;
+
+import lombok.Data;
+import org.yaml.snakeyaml.YAMLField;
+
+@Data
+public class YAMLFieldBean3 {
+
+    @YAMLField(order = 2)
+    private String name;
+
+    @YAMLField(order = 2)
+    private Coordinates type;
+
+    @YAMLField(order = 2)
+    private Integer age;
+
+    private String line;
+
+    private String text;
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean4.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean4.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue307;
+
+import lombok.Data;
+import org.yaml.snakeyaml.YAMLField;
+
+@Data
+public class YAMLFieldBean4 {
+
+    @YAMLField(order = -1)
+    private String name;
+
+    @YAMLField(order = 0)
+    private Coordinates type;
+
+    @YAMLField(order = 0)
+    private Integer age;
+
+    private String line;
+
+    @YAMLField(order = 2)
+    private String text;
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean5.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue307/YAMLFieldBean5.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2008, http://www.snakeyaml.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yaml.snakeyaml.issues.issue307;
+
+import lombok.Data;
+import org.yaml.snakeyaml.YAMLField;
+
+@Data
+public class YAMLFieldBean5 extends YAMLFieldBean1{
+
+    @YAMLField(order = -1)
+    public String pojoName;
+}

--- a/src/test/resources/issues/issue307.yaml
+++ b/src/test/resources/issues/issue307.yaml
@@ -1,0 +1,8 @@
+name: tian
+type:
+  x: 254
+  y: 255
+  z: 256
+age: 22
+line: twelve
+text: omit


### PR DESCRIPTION
Fix issue [#307](https://bitbucket.org/asomov/snakeyaml/issues/307/add-annotation-retrieval-methods-to):

add an annotation class `YAMLField`
Defining a class `YAMLFieldBean1`, when serializing it, the fileds will sorted in the order of `order`
```
public class YAMLFieldBean1 {

    @YAMLField(order = 1)
    private String name;

    @YAMLField(order = 2)
    private Coordinates type;

    @YAMLField(order = 3)
    private Integer age;

    @YAMLField(order = 4)
    private String line;

    @YAMLField(order = 5)
    private String text;
}
```
**output**
```
name: tian
type:
  x: 254
  y: 255
  z: 256
age: 22
line: twelve
text: omit
```